### PR TITLE
Fixes the CBOR_UNEXPECTED_TYPE error during FIDO2 registration.

### DIFF
--- a/app/src/main/java/pl/lebihan/authnkey/FidoCommands.kt
+++ b/app/src/main/java/pl/lebihan/authnkey/FidoCommands.kt
@@ -36,8 +36,8 @@ object FidoCommands {
                 4 to array {
                     for ((type, alg) in pubKeyCredParams) {
                         map {
-                            "type" to type
                             "alg" to alg
+                            "type" to type
                         }
                     }
                 }


### PR DESCRIPTION
In the buildMakeCredential function, the "type" key was incorrectly placed before the "alg" key. According to the CTAP2 specification (which follows Canonical CBOR rules), map keys must be sorted primarily by their byte string length. Since "alg" (length 3) is shorter than "type" (length 4), "alg" must precede "type".

Strict authenticators strictly enforce this canonical order and will reject any requests that do not comply.

Changes: Reordered the keys in the pubKeyCredParams map to ensure compliance with the specification.

[Fixes the CBOR_UNEXPECTED_TYPE error during FIDO2 registration.](https://github.com/mimi89999/Authnkey/issues/52)