### PR TITLE
Feature: add per-app language selection support

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -36,6 +36,11 @@ android {
         }
     }
 
+    androidResources {
+        @Suppress("UnstableApiUsage")
+        generateLocaleConfig = true
+    }
+
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17

--- a/app/src/main/res/resources.properties
+++ b/app/src/main/res/resources.properties
@@ -1,0 +1,1 @@
+unqualifiedResLocale=en


### PR DESCRIPTION
This PR enables per-app language support by turning on `generateLocaleConfig` in `androidResources`.

With this, Android knows which languages the app supports, and users can choose an app-specific language without changing the device language.

The screenshots show the new "Language" field in the app settings and the screen where the user can select the desired app language:
<p float="left">
  <img src="https://github.com/user-attachments/assets/dcfb178e-b722-4a9e-b55a-0dc83268b47d" width="200" />
  <img src="https://github.com/user-attachments/assets/169ac251-e940-40dd-be99-c05d02cebd43" width="200" />
</p>

See official documentation: [auto-localeconfig](https://developer.android.com/guide/topics/resources/app-languages#auto-localeconfig)
