### PR TITLE
Handle `noMcGaPermissionsWithClientPin` for fingerprint-only auth keys

### DIFF
--- a/app/src/main/java/pl/lebihan/authnkey/AuthnkeyError.kt
+++ b/app/src/main/java/pl/lebihan/authnkey/AuthnkeyError.kt
@@ -17,4 +17,7 @@ sealed class AuthnkeyError(message: String) : Exception(message) {
 
     // On-device UV errors
     class UvBlocked : AuthnkeyError("Biometric verification is blocked")
+
+    // noMcGaPermissionsWithClientPin errors
+    class UvRequiredPinCannotBeUsed : AuthnkeyError("User verification required but PIN cannot be used for this operation")
 }

--- a/app/src/main/java/pl/lebihan/authnkey/CTAP.kt
+++ b/app/src/main/java/pl/lebihan/authnkey/CTAP.kt
@@ -115,6 +115,22 @@ data class DeviceInfo(
 
     val supportsBuiltInUv: Boolean
         get() = options["uv"] == true
+
+    /** True when the authenticator reports noMcGaPermissionsWithClientPin = true */
+    val noMcGaPermissionsWithClientPin: Boolean
+        get() = options["noMcGaPermissionsWithClientPin"] == true
+
+    /**
+     * Whether Client PIN can be used to obtain pinUvAuthToken with mc/ga permissions.
+     * Returns true only when clientPin is set AND noMcGaPermissionsWithClientPin is
+     * absent or false.
+     */
+    val canUsePinForMcGa: Boolean
+        get() = clientPinSet && !noMcGaPermissionsWithClientPin
+
+    /** Whether the alwaysUv option is set */
+    val alwaysUv: Boolean
+        get() = options["alwaysUv"] == true
 }
 
 object CTAP {

--- a/app/src/main/java/pl/lebihan/authnkey/CredentialProviderActivity.kt
+++ b/app/src/main/java/pl/lebihan/authnkey/CredentialProviderActivity.kt
@@ -249,7 +249,6 @@ class CredentialProviderActivity : AppCompatActivity() {
         try {
             val json = JSONObject(requestJson!!)
 
-            // Check userVerification in authenticatorSelection (create) or directly (get)
             val uvString = if (isCreateRequest) {
                 json.optJSONObject("authenticatorSelection")?.optString("userVerification", "preferred")
             } else {
@@ -257,29 +256,15 @@ class CredentialProviderActivity : AppCompatActivity() {
             }
             userVerification = UserVerification.fromString(uvString)
 
-            // Check if allowCredentials is empty (discoverable credential flow needs PIN)
-            val allowCredentialsEmpty = if (!isCreateRequest) {
-                !json.has("allowCredentials") || json.getJSONArray("allowCredentials").length() == 0
-            } else false
-
-            // For required/preferred, or discoverable flow, ask for PIN upfront to minimize NFC taps
-            if (userVerification != UserVerification.DISCOURAGED || allowCredentialsEmpty) {
-                showPinDialogFirst()
-            }
-            // If discouraged with allowCredentials, just wait for key connection
+            // Don't show PIN input yet — we need device info first to check
+            // noMcGaPermissionsWithClientPin. The correct prompt will be shown
+            // in processRequest() after authenticatorGetInfo.
+            // Just stay in WAITING state with "connect your key" instruction.
 
         } catch (e: Exception) {
-            Log.e(TAG, "Error checking PIN requirement", e)
-            // Assume preferred
+            Log.e(TAG, "Error checking UV requirement", e)
             userVerification = UserVerification.PREFERRED
-            showPinDialogFirst()
         }
-    }
-
-    private fun showPinDialogFirst() {
-        setInstruction(getString(R.string.instruction_enter_pin))
-        setState(CredentialBottomSheet.State.PIN)
-        bottomSheet?.showPinInput(true)
     }
 
     private fun showPinDialogWithBiometric(retries: Int, requestJson: JSONObject) {
@@ -499,52 +484,72 @@ class CredentialProviderActivity : AppCompatActivity() {
 
                 // Check if clientPin is actually set on the device
                 val deviceHasPin = deviceInfo?.clientPinSet == true
-                val alwaysUv = deviceInfo?.options?.get("alwaysUv") == true
+                val alwaysUv = deviceInfo?.alwaysUv == true
                 deviceSupportsUv = deviceInfo?.supportsBuiltInUv == true
 
+                val noMcGa = deviceInfo?.noMcGaPermissionsWithClientPin == true
+                val canPinForMcGa = deviceInfo?.canUsePinForMcGa == true
+
                 when {
-                    // We already have PIN from pre-prompt
-                    deviceHasPin && pendingPin != null -> {
+                    // 1. noMcGaPermissionsWithClientPin=true + device supports built-in UV
+                    //    → go straight to biometric; PIN cannot help for mc/ga
+                    noMcGa && deviceSupportsUv -> {
+                        authenticateWithUvAndExecute(json)
+                    }
+
+                    // 2. noMcGaPermissionsWithClientPin=true + NO built-in UV
+                    //    → impossible to perform mc/ga — UV required but unavailable,
+                    //      PIN can't carry mc/ga permissions
+                    noMcGa && !deviceSupportsUv -> {
+                        throw AuthnkeyError.UvRequiredPinCannotBeUsed()
+                    }
+
+                    // 3. We have a pending PIN from pre-connection and PIN is usable for mc/ga
+                    canPinForMcGa && pendingPin != null -> {
                         setInstruction(getString(R.string.instruction_authenticating))
                         authenticateAndExecute(pendingPin!!, json)
                     }
-                    // UV required but device has no PIN and no built-in UV - fail
+
+                    // 4. UV required but no PIN and no UV → fail
                     userVerification == UserVerification.REQUIRED && !deviceHasPin && !deviceSupportsUv -> {
                         throw AuthnkeyError.UserVerificationRequiredNoPin()
                     }
-                    // UV required/preferred, device supports built-in UV but no PIN set
-                    // -> go directly to biometric
+
+                    // 5. Device supports UV but no PIN set → use UV directly
                     userVerification != UserVerification.DISCOURAGED && deviceSupportsUv && !deviceHasPin -> {
                         authenticateWithUvAndExecute(json)
                     }
-                    // UV required/preferred, device has both PIN and built-in UV
-                    // -> show PIN input with biometric option
-                    userVerification != UserVerification.DISCOURAGED && deviceHasPin && deviceSupportsUv -> {
+
+                    // 6. Device has both PIN (usable for mc/ga) and UV → offer choice
+                    userVerification != UserVerification.DISCOURAGED && canPinForMcGa && deviceSupportsUv -> {
                         val retries = withContext(Dispatchers.IO) { protocol.getPinRetries() }.getOrDefault(8)
                         showPinDialogWithBiometric(retries, json)
                     }
-                    // alwaysUv but device has no PIN - fail
+
+                    // 7. alwaysUv but no PIN and no UV → fail
                     alwaysUv && !deviceHasPin && !deviceSupportsUv -> {
                         throw AuthnkeyError.UserVerificationRequiredNoPin()
                     }
-                    // UV required/preferred and device has PIN only - need to get PIN
-                    userVerification != UserVerification.DISCOURAGED && deviceHasPin -> {
+
+                    // 8. PIN usable for mc/ga, no UV → show PIN dialog
+                    userVerification != UserVerification.DISCOURAGED && canPinForMcGa -> {
                         val retries = withContext(Dispatchers.IO) { protocol.getPinRetries() }.getOrDefault(8)
                         showPinDialog(retries, json)
                     }
-                    // UV discouraged but device has alwaysUv - need PIN or UV anyway
+
+                    // 9. UV discouraged but alwaysUv forces verification
                     userVerification == UserVerification.DISCOURAGED && alwaysUv -> {
                         if (deviceSupportsUv) {
-                            // Use built-in UV silently since UV is discouraged but alwaysUv forces it
                             authenticateWithUvAndExecute(json)
-                        } else if (deviceHasPin) {
+                        } else if (canPinForMcGa) {
                             val retries = withContext(Dispatchers.IO) { protocol.getPinRetries() }.getOrDefault(8)
                             showPinDialog(retries, json)
                         } else {
                             throw AuthnkeyError.UserVerificationRequiredNoPin()
                         }
                     }
-                    // UV discouraged or preferred with no PIN - try without
+
+                    // 10. No verification needed — try without PIN/UV
                     else -> {
                         tryExecuteWithoutPin(json)
                     }
@@ -683,48 +688,67 @@ class CredentialProviderActivity : AppCompatActivity() {
                     if (e is CTAP.Exception) {
                         when (e.error) {
                             CTAP.Error.UV_INVALID -> {
-                                // Biometric didn't match — let user retry or switch to PIN
                                 Log.d(TAG, "UV_INVALID: biometric verification failed")
                                 val uvRetries = withContext(Dispatchers.IO) {
                                     protocol.getUvRetries()
                                 }.getOrDefault(0)
+
+                                val canFallbackToPin = deviceInfo?.canUsePinForMcGa == true
 
                                 if (uvRetries > 0) {
                                     runOnUiThread {
                                         showProgress(false)
                                         setInstruction(getString(R.string.error_uv_invalid_retries, uvRetries))
                                         setState(CredentialBottomSheet.State.PIN)
-                                        bottomSheet?.showPinInput(true)
-                                        bottomSheet?.showBiometricOption(true)
+                                        if (canFallbackToPin) {
+                                            bottomSheet?.showPinInput(true)
+                                        }
+                                        bottomSheet?.showBiometricOption(true)  // Always allow retry
                                     }
-                                } else {
+                                } else if (canFallbackToPin) {
                                     // UV exhausted, fall back to PIN
                                     fallbackToPinAfterUvFailure(requestJson)
+                                } else {
+                                    // UV exhausted and PIN can't do mc/ga — fail definitively
+                                    throw AuthnkeyError.UvRequiredPinCannotBeUsed()
                                 }
                                 return@launch
                             }
                             CTAP.Error.UV_BLOCKED -> {
-                                Log.d(TAG, "UV_BLOCKED: falling back to PIN")
-                                fallbackToPinAfterUvFailure(requestJson)
+                                val canFallbackToPin = deviceInfo?.canUsePinForMcGa == true
+                                if (canFallbackToPin) {
+                                    Log.d(TAG, "UV_BLOCKED: falling back to PIN")
+                                    fallbackToPinAfterUvFailure(requestJson)
+                                } else {
+                                    Log.d(TAG, "UV_BLOCKED: PIN cannot be used for mc/ga, failing")
+                                    throw AuthnkeyError.UvRequiredPinCannotBeUsed()
+                                }
                                 return@launch
                             }
                             CTAP.Error.INVALID_SUBCOMMAND,
                             CTAP.Error.INVALID_COMMAND,
                             CTAP.Error.INVALID_PARAMETER -> {
-                                // Authenticator doesn't actually support UV subcommand,
-                                // fall back to PIN silently
                                 Log.d(TAG, "UV subcommand not supported, falling back to PIN")
                                 deviceSupportsUv = false
-                                fallbackToPinAfterUvFailure(requestJson)
+                                val canFallbackToPin = deviceInfo?.canUsePinForMcGa == true
+                                if (canFallbackToPin) {
+                                    fallbackToPinAfterUvFailure(requestJson)
+                                } else {
+                                    throw AuthnkeyError.UvRequiredPinCannotBeUsed()
+                                }
                                 return@launch
                             }
                             CTAP.Error.OPERATION_DENIED -> {
-                                // User denied on device (e.g. tapped cancel on the key)
+                                val canFallbackToPin = deviceInfo?.canUsePinForMcGa == true
                                 runOnUiThread {
                                     showProgress(false)
                                     setInstruction(getString(R.string.error_operation_denied))
-                                    setState(CredentialBottomSheet.State.PIN)
-                                    bottomSheet?.showPinInput(true)
+                                    if (canFallbackToPin) {
+                                        setState(CredentialBottomSheet.State.PIN)
+                                        bottomSheet?.showPinInput(true)
+                                    } else {
+                                        setState(CredentialBottomSheet.State.ERROR)
+                                    }
                                     if (deviceSupportsUv) {
                                         bottomSheet?.showBiometricOption(true)
                                     }
@@ -748,8 +772,8 @@ class CredentialProviderActivity : AppCompatActivity() {
     }
 
     private suspend fun fallbackToPinAfterUvFailure(requestJson: JSONObject) {
-        val deviceHasPin = deviceInfo?.clientPinSet == true
-        if (deviceHasPin) {
+        val canPinForMcGa = deviceInfo?.canUsePinForMcGa == true
+        if (canPinForMcGa) {
             val protocol = pinProtocol ?: throw AuthnkeyError.PinProtocolNotInitialized()
             val retries = withContext(Dispatchers.IO) { protocol.getPinRetries() }.getOrDefault(8)
             runOnUiThread {
@@ -760,7 +784,7 @@ class CredentialProviderActivity : AppCompatActivity() {
                 // Don't show biometric option since UV is blocked/unsupported
             }
         } else {
-            throw AuthnkeyError.UvBlocked()
+            throw AuthnkeyError.UvRequiredPinCannotBeUsed()
         }
     }
 

--- a/app/src/main/java/pl/lebihan/authnkey/ErrorMapping.kt
+++ b/app/src/main/java/pl/lebihan/authnkey/ErrorMapping.kt
@@ -20,6 +20,7 @@ fun Throwable.toUserMessage(context: Context): String = when (this) {
     is AuthnkeyError.UserVerificationRequiredNoPin -> context.getString(R.string.error_uv_required_no_pin)
     is AuthnkeyError.PinBlocked -> context.getString(R.string.error_pin_blocked)
     is AuthnkeyError.UvBlocked -> context.getString(R.string.error_uv_blocked)
+    is AuthnkeyError.UvRequiredPinCannotBeUsed -> context.getString(R.string.error_uv_required_pin_cannot_auth)
 
     // Fallback
     else -> this.message ?: context.getString(R.string.error_unknown)
@@ -41,5 +42,6 @@ private fun CTAP.Error.toUserMessage(context: Context): String = when (this) {
     CTAP.Error.KEEPALIVE_CANCEL -> context.getString(R.string.error_operation_cancelled)
     CTAP.Error.UV_BLOCKED -> context.getString(R.string.error_uv_blocked)
     CTAP.Error.UV_INVALID -> context.getString(R.string.error_uv_failed)
+    CTAP.Error.UNAUTHORIZED_PERMISSION -> context.getString(R.string.error_unauthorized_permission)
     else -> context.getString(R.string.error_ctap_unknown, this.name)
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,6 +51,12 @@
     <string name="error_uv_failed">Biometric verification failed</string>
     <string name="error_uv_invalid_retries">Fingerprint not recognized. %1$d retries remaining</string>
 
+    <!-- noMcGaPermissionsWithClientPin related -->
+    <string name="error_uv_required_pin_cannot_auth">This security key requires fingerprint verification for sign-in and passkey creation. PIN cannot be used for this operation.</string>
+    <string name="error_pin_cannot_be_used_for_auth">PIN cannot be used for authentication on this security key. Use fingerprint instead.</string>
+    <string name="error_unauthorized_permission">The security key rejected this request. The PIN cannot be used for this type of operation.</string>
+    <string name="instruction_use_fingerprint">Use the fingerprint sensor on your security key</string>
+
     <!-- Errors -->
     <string name="error_format">%1$s\n\nTry again or cancel</string>
     <string name="error_retry_format">%1$s\n\nTry again</string>


### PR DESCRIPTION
Security keys with fingerprint sensors (Authentrend ATKey.Card NFC tested) report `noMcGaPermissionsWithClientPin=true` in their `authenticatorGetInfo` response. This CTAP 2.1 flag means the authenticator's Client PIN cannot be used to obtain tokens with Make Credential or Get Assertion permissions. Fingerprint verification is the only way to create or use passkeys.

Authnkey didn't check this flag. It prompted for a PIN upfront (before the key even connected), and when the key did connect, it offered PIN entry alongside the fingerprint option. If a user entered their PIN, the authenticator rejected it with an error because the PIN token can't carry `mc`/`ga` (Make Credential / Get Assertion) permissions on these devices. The user saw a confusing generic error instead of being guided to use their fingerprint.

### Fix

The app now queries the `noMcGaPermissionsWithClientPin` option from `authenticatorGetInfo` and uses it to drive the verification flow:

* **Fingerprint-only auth keys** (`noMcGaPermissionsWithClientPin=true`, `uv=true`): Go straight to fingerprint verification. No PIN dialog is shown. If fingerprint fails and retries remain, only the biometric retry button is shown - not a PIN field.

* **Standard PIN-only keys** (`noMcGaPermissionsWithClientPin` absent, `uv=false`): Unchanged. PIN dialog as before.

* **Keys with both PIN and fingerprint, flag false**: Unchanged. PIN dialog with "Use fingerprint" option.

* **UV failure on fingerprint-only keys**: If fingerprint is blocked/exhausted and PIN can't substitute, the user gets a clear error explaining that fingerprint is required and PIN cannot be used for this operation.

The pre-connection PIN prompt has been removed. Previously the app showed a PIN field immediately on launch before knowing anything about the connected key. Now it waits for `authenticatorGetInfo` to determine the correct verification method. This ensures fingerprint-only keys never see an irrelevant PIN prompt.

Note: Credential management, PIN changes, and other non-mc/ga operations are unaffected. The spec only restricts `mc` and `ga` permissions, so PIN-based credential listing continues to work normally on these devices.

### Testing

Tested with:

* Fingerprint security key with `noMcGaPermissionsWithClientPin=true` 
  -  passkey creation and sign-in via fingerprint only, no PIN prompt shown

* Standard PIN-only security key 
  - now waits for card to be presented before prompting for pin / UV (fingerprint) / UP (user presence) 
    - I don't have a UP only token so can someone check that please?

* UV failure scenarios (UV_INVALID, UV_BLOCKED, OPERATION_DENIED) on fingerprint-only keys 
  - correct error messages, no PIN fallback offered