### PR TITLE
Fix NFC detection for already-present security keys

### DIFF
--- a/app/src/main/java/pl/lebihan/authnkey/CredentialProviderActivity.kt
+++ b/app/src/main/java/pl/lebihan/authnkey/CredentialProviderActivity.kt
@@ -185,6 +185,18 @@ class CredentialProviderActivity : AppCompatActivity() {
             return
         }
 
+        // Check if we were started with an NFC tag already present
+        val action = intent?.action
+        if (action == NfcAdapter.ACTION_TECH_DISCOVERED || action == NfcAdapter.ACTION_TAG_DISCOVERED || action == NfcAdapter.ACTION_NDEF_DISCOVERED) {
+            val tag = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                intent.getParcelableExtra(NfcAdapter.EXTRA_TAG, Tag::class.java)
+            } else {
+                @Suppress("DEPRECATION")
+                intent.getParcelableExtra(NfcAdapter.EXTRA_TAG)
+            }
+            tag?.let { handleNfcTag(it) }
+        }
+
         // Check if PIN is likely required based on userVerification preference
         checkPinRequirement()
     }
@@ -297,28 +309,43 @@ class CredentialProviderActivity : AppCompatActivity() {
         super.onResume()
 
         nfcAdapter?.let { adapter ->
-            val intent = Intent(this, javaClass).addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
-
-            val pendingIntent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-                val options = ActivityOptions.makeBasic().apply {
-                    pendingIntentCreatorBackgroundActivityStartMode =
-                        ActivityOptions.MODE_BACKGROUND_ACTIVITY_START_ALLOWED
-                }
-                PendingIntent.getActivity(
-                    this, 0, intent,
-                    PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
-                    options.toBundle()
-                )
+            // Use ReaderMode for more reliable NFC detection, especially for already-present tags
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+                val flags = NfcAdapter.FLAG_READER_NFC_A or
+                        NfcAdapter.FLAG_READER_NFC_B or
+                        NfcAdapter.FLAG_READER_SKIP_NDEF_CHECK
+                adapter.enableReaderMode(this, { tag ->
+                    runOnUiThread {
+                        handleNfcTag(tag)
+                    }
+                }, flags, null)
             } else {
-                PendingIntent.getActivity(
+                // Fallback for older devices
+                val intent = Intent(this, javaClass).addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
+                val pendingIntent = PendingIntent.getActivity(
                     this, 0, intent,
                     PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
                 )
+                val filters = arrayOf(IntentFilter(NfcAdapter.ACTION_TECH_DISCOVERED))
+                val techLists = arrayOf(arrayOf(IsoDep::class.java.name))
+                adapter.enableForegroundDispatch(this, pendingIntent, filters, techLists)
             }
+        }
 
-            val filters = arrayOf(IntentFilter(NfcAdapter.ACTION_TECH_DISCOVERED))
-            val techLists = arrayOf(arrayOf(IsoDep::class.java.name))
-            adapter.enableForegroundDispatch(this, pendingIntent, filters, techLists)
+        // Also check intent for already-present tag
+        if (currentTransport?.isConnected != true) {
+            val action = intent?.action
+            if (action == NfcAdapter.ACTION_TECH_DISCOVERED || action == NfcAdapter.ACTION_TAG_DISCOVERED) {
+                val tag = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    intent.getParcelableExtra(NfcAdapter.EXTRA_TAG, Tag::class.java)
+                } else {
+                    @Suppress("DEPRECATION")
+                    intent.getParcelableExtra(NfcAdapter.EXTRA_TAG)
+                }
+                tag?.let {
+                    handleNfcTag(it)
+                }
+            }
         }
 
         val usbAttachFilter = IntentFilter(UsbManager.ACTION_USB_DEVICE_ATTACHED)
@@ -336,6 +363,9 @@ class CredentialProviderActivity : AppCompatActivity() {
     override fun onPause() {
         super.onPause()
         nfcAdapter?.disableForegroundDispatch(this)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+            nfcAdapter?.disableReaderMode(this)
+        }
         try {
             unregisterReceiver(usbAttachReceiver)
         } catch (e: Exception) {


### PR DESCRIPTION
Fix NFC tag detection for already-present cards

The credential provider activity was unable to detect NFC security keys that were already present when the authentication flow started. Users had to remove and re-insert their security key for the app to recognize it.

The root cause was that `enableForegroundDispatch()` only triggers for tags discovered after it's enabled, not for tags already present on the NFC reader. This created a race condition where a key held during the initial prompt would be ignored.

Switch to `enableReaderMode()` which actively polls for NFC tags, allowing detection of already-present cards. This API (available since API 19) provides more reliable discovery for authentication flows where the user may already be holding their key when the UI appears.

**Implications and compatibility:**

- Existing functionality is preserved. Cards tapped after the UI appears continue to work as before.
- ReaderMode is available on all Android devices running API 19+ (Android 4.4+). The app's minimum SDK is 34, so this is fully supported.
- A fallback to `enableForegroundDispatch()` is retained for compatibility, though it is not expected to be used given the app's minimum SDK requirement.
- The change only affects NFC detection behavior; USB security keys are unaffected.

**Testing:**

Tested using an Authentrend ATKey.Card NFC card. Verified that:
- Authentication succeeds when the card is already present on the NFC reader when the prompt appears
- Authentication continues to work when tapping the card after the prompt appears
- Card removal and re-presenting still works correctly