### PR TITLE
fix: handle FIDO PIN policy violation gracefully for oversized inputs

### DIFF
--- a/app/src/main/java/pl/lebihan/authnkey/PinProtocol.kt
+++ b/app/src/main/java/pl/lebihan/authnkey/PinProtocol.kt
@@ -226,6 +226,9 @@ class PinProtocol(private val transport: FidoTransport) {
 
         try {
             val newPinBytes = newPin.toByteArray(Charsets.UTF_8)
+            if (newPinBytes.size > 64) {
+                return Result.failure(PinSetError.PinPolicyViolation())
+                }
             val newPinPadded = ByteArray(64)
             newPinBytes.copyInto(newPinPadded, 0, 0, newPinBytes.size)
 
@@ -279,6 +282,9 @@ class PinProtocol(private val transport: FidoTransport) {
             val currentPinHashLeft16 = currentPinHash.copyOf(16)
 
             val newPinBytes = newPin.toByteArray(Charsets.UTF_8)
+            if (newPinBytes.size > 64) {
+                return Result.failure(PinSetError.PinPolicyViolation())
+                }
             val newPinPadded = ByteArray(64)
             newPinBytes.copyInto(newPinPadded, 0, 0, newPinBytes.size)
 


### PR DESCRIPTION
When PIN length > 64, it triggers: src.length=65 srcPos=0 dst.length=64 dstPos=0 length=64.
After the fix, "PIN Policy Violation" is correctly prompted (Note: This prompt currently only supports English).
Verified with lengths 65 and 130.

Note: This approach might not be the optimal implementation.